### PR TITLE
ci: add Dependabot configuration and release notes template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,54 @@
+changelog:
+  categories:
+    - title: "🚨 Breaking Changes"
+      labels:
+        - major
+    - title: "🪛 Changes"
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - major
+          - dependencies
+          - documentation
+          - enhancement
+          - chores
+          - bug
+          - release
+          - CICD
+    - title: "❇️ Enhancement / New Features"
+      labels:
+        - enhancement
+      exclude:
+        labels:
+          - major
+    - title: "🐞 Bug Fixes"
+      labels:
+        - bug
+      exclude:
+        labels:
+          - major
+    - title: "🧹 Chores"
+      labels:
+        - chores
+      exclude:
+        labels:
+          - major
+    - title: "📄 Documentation"
+      labels:
+        - documentation
+      exclude:
+        labels:
+          - major
+    - title: "🤖 CI / CD"
+      labels:
+        - CICD
+      exclude:
+        labels:
+          - major
+    - title: "🔧 Dependencies"
+      labels:
+        - dependencies
+      exclude:
+        labels:
+          - major


### PR DESCRIPTION
## Summary

Set up release infrastructure previously managed by `release-helper` (now archived).
Reference: MasatoMakino/StateAtoms configuration.

**Scope:**
- Dependabot configuration (GitHub Actions weekly, npm daily with cooldown)
- Release notes template (8-category changelog for GitHub Releases)
- PR labels created via GitHub API: `release`, `CICD`, `chores`, `major`

**Unchanged:**
- Existing CI and GitHub Pages workflows
- npm publish workflow (to be added separately)

## Test Plan

- [ ] Verify YAML syntax is valid
- [ ] Verify CI passes (no impact on existing workflows)
- [ ] Verify labels appear in repository settings
- [ ] After merge: Dependabot PRs should appear within 24 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management to regularly check and update dependencies across GitHub Actions and npm packages with staggered schedules based on update severity.
  * Established automated changelog organization system to categorize release notes by type (breaking changes, features, bug fixes, documentation, and more) for clearer release communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->