### PR TITLE
chore: add lint script to package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
           cache: "npm"
       - run: npm ci
       - name: Run Biome
-        run: npx biome ci .
+        run: npm run lint
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build": "tsc",
     "watch": "tsc -W",
     "testRun": "node ./bin/CLI.js build --srcDir ./demoSrc",
+    "lint": "biome ci .",
     "dev": "node ./bin/CLI.js dev --srcDir ./demoSrc --host 0.0.0.0",
     "pre-commit": "biome format --write --no-errors-on-unmatched --files-ignore-unknown=true",
     "pre-push": "biome ci . && vitest --run"


### PR DESCRIPTION
## Summary

- Add a `lint` script (`biome ci .`) to package.json for consistent local and CI usage
- Update CI workflow to use `npm run lint` instead of calling `npx biome ci` directly

**Changes:**
- `package.json`: Added `"lint": "biome ci ."` to scripts
- `.github/workflows/ci.yml`: Replaced `npx biome ci .` with `npm run lint`

**Unchanged:**
- `pre-push` hook still calls `biome ci .` directly (runs outside npm script context)

## Test Plan

- [ ] CI passes with the new `npm run lint` step
- [ ] `npm run lint` works locally inside DevContainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI linting process through improved build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->