### PR TITLE
ci: add npm publish workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -96,7 +96,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11
+        run: npm install -g "npm@^11.10.0"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Add `workflow_dispatch`-triggered npm publish workflow using OIDC trusted publishing (tokenless authentication). No `NPM_TOKEN` secret required.

## Scope

**Changes:**
- New `.github/workflows/npm_publish.yml` workflow

**Unchanged:**
- Existing CI and GitHub Pages workflows
- Package source code

## Design

- **Two-job structure**: `validate` runs outside the `npm-publish` environment so validation failures skip reviewer approval
- **Tag-Release binding**: Validates tag format, tag existence, and that the GitHub Release is published (not draft)
- **OIDC trusted publishing**: Uses `id-token: write` permission for npm authentication with automatic provenance
- **Version consistency**: Verifies `package.json` version matches the tag
- **SHA pinning**: Uses same pinned SHAs as existing workflows

## Prerequisites (Web UI setup required)

1. **GitHub Environment**: Create `npm-publish` environment with required reviewer (`MasatoMakino`)
2. **npm Trusted Publisher**: Register GitHub Actions as trusted publisher on npmjs.com
   - Owner: `MasatoMakino`, Repository: `demo-showcase`, Workflow: `npm_publish.yml`, Environment: `npm-publish`

## Test plan

- [ ] Verify workflow syntax passes GitHub Actions validation after merge
- [ ] Configure GitHub Environment and npm Trusted Publisher via Web UI
- [ ] Run workflow with `v0.1.1` tag to validate the pipeline (publish step expected to fail with 403 as version already exists)
- [ ] Verify with next release (`/version-release` then trigger workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated npm publish workflow triggered manually with tag input.
  * Enforces tag format and existence, requires a non-draft release, and validates package version matches tag.
  * Runs build and publish steps, producing a public package with provenance; prevents publishing when validations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->