### PR TITLE
ci: split gh-pages workflow permissions to job level

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,17 +6,14 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   build-pages:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -44,6 +41,9 @@ jobs:
           path: ./docs
 
   deploy-pages:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Mitigate Trivy/hackerbot-claw incident risk by splitting top-level workflow permissions into job-level permissions.

**Changes:**
- `build-pages` job: `contents: read` only
- `deploy-pages` job: `pages: write` + `id-token: write` only
- Removed top-level `permissions` block

**Unchanged:**
- Workflow triggers, steps, and action versions

## Test plan

- [ ] CI `build-pages` job passes on this PR
- [ ] After merge, `deploy-pages` deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to use more granular permission scoping for build and deployment jobs, enhancing security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->