### PR TITLE
ci: sync npm_publish.yml with npm-oidc-infra-init template

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -42,8 +42,8 @@ jobs:
         id: resolve_tag
         run: |
           TAG_REF=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" \
-            --jq '.object.sha + " " + .object.type' 2>/dev/null) || {
-            echo "::error::Tag $TAG does not exist in repository"
+            --jq '.object.sha + " " + .object.type') || {
+            echo "::error::Failed to look up tag $TAG"
             exit 1
           }
           TAG_OBJ_SHA=$(echo "$TAG_REF" | cut -d' ' -f1)
@@ -52,7 +52,7 @@ jobs:
             COMMIT_SHA="$TAG_OBJ_SHA"
           else
             COMMIT_SHA=$(gh api "repos/${REPO}/git/tags/${TAG_OBJ_SHA}" \
-              --jq '.object.sha' 2>/dev/null) || {
+              --jq '.object.sha') || {
               echo "::error::Failed to resolve annotated tag $TAG"
               exit 1
             }
@@ -94,12 +94,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.validate.outputs.commit_sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## Summary

Sync `.github/workflows/npm_publish.yml` with the latest `npm-oidc-infra-init` skill template.

## Scope

**Changes:**
- Replace `inputs.tag` dispatch model with `github.ref_name` (dispatch via `--ref <tag>`)
- Add job-level `permissions` to validate job
- Consolidate environment variables at job level (command injection prevention)
- Add "Verify dispatch ref is a tag" step
- Enhance tag validation: resolve annotated tags and detect force-moves
- Pass validated `commit_sha` to publish job for checkout
- Simplify Release verification (`@tsv` + `cut` instead of `jq`)
- Move version check after Setup Node.js; pass version via `env:` instead of inline `${{ }}`
- Re-pin `actions/checkout` and `actions/setup-node` to SHA for v6
- Add CLI/Web UI usage comments

**Unchanged:**
- publish job structure (npm ci, build, publish steps)
- npm OIDC trusted publishing configuration
- Environment protection (`npm-publish`)

## Test Plan

- [ ] YAML syntax is valid (CI will validate)
- [ ] All `${{ }}` expressions are passed through `env:` variables, not inline in `run:` blocks
- [ ] GitHub Actions are SHA-pinned with version comments
- [ ] Dispatch from a tag ref: `gh workflow run npm_publish.yml --ref <tag>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved npm publishing workflow with stricter tag validation and commit verification to prevent incorrect releases.
  * Ensures a corresponding non-draft GitHub Release exists before publishing.
  * Aligns package version with the validated tag and streamlines Node.js setup and publish steps for more reliable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->